### PR TITLE
allow import of mikrotik format

### DIFF
--- a/rfc3442.htm
+++ b/rfc3442.htm
@@ -216,7 +216,15 @@
         const octetRegex = /^[\dabcdef][\dabcdef]$/;
 
         function Import() {
-            let data = document.querySelector("#Result").value.toLowerCase().split(":").reverse();
+            let data = document.querySelector("#Result").value.toLowerCase();
+            if(data.startsWith("0x")) {
+                data = data.slice(2);
+            }
+            if(data.indexOf(":") == -1) {
+                data = data.match(/.{2}/g).reverse();
+            } else {
+                data = data.split(":").reverse();
+            }
 
             if(data.length < 6){
                 alert("Invalid input");


### PR DESCRIPTION
Importing will work if the input is prefixed with `0x` or doesn't have colons separating bytes.